### PR TITLE
feat: fix some colors

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -98,7 +98,7 @@ import { donationOptions } from '~data';
 	footer {
 		--section-1-height: 50%;
 		--section-2-height: 50%;
-		background-color: var(--color-black-light);
+		background-color: var(--color-yellow-mid);
 	}
 
 	footer section {
@@ -107,6 +107,10 @@ import { donationOptions } from '~data';
 
 	footer section:last-of-type {
 		padding-block-end: var(--s4);
+	}
+
+	footer a {
+		color: var(--color-black-dark);
 	}
 
 	@supports (width: min(460px, 100%)) {
@@ -128,8 +132,9 @@ import { donationOptions } from '~data';
 		margin-left: 0.4rem;
 	}
 </style>
-
-<script>
+<!-- TODO: Split-color background relies on some JavaScript math.
+EJ to fix. -->
+<!-- <script>
 	document.addEventListener('DOMContentLoaded', () => {
 		// create a media query for max-width: 990px;
 		const mq = window.matchMedia('(max-width: 990px)');
@@ -181,7 +186,8 @@ import { donationOptions } from '~data';
 			);
 		}
 
-		calculateHeights();
-		mq.addEventListener('change', calculateHeights);
+
+		// calculateHeights();
+		// mq.addEventListener('change', calculateHeights);
 	});
-</script>
+</script> -->

--- a/src/components/GetInTouch.astro
+++ b/src/components/GetInTouch.astro
@@ -64,6 +64,9 @@
 	</li>
 </ul>
 <style>
+	a {
+		color: var(--color-black-dark) !important;
+	}
 	svg {
 		height: 20px;
 		width: 20px;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -241,6 +241,10 @@ const jsonLDSchema = JSON.stringify(
 				color: var(--color-blue-mid);
 			}
 
+			.u-bg-black a {
+				color: var(--color-yellow-mid);
+			}
+
 			.l-center {
 				box-sizing: content-box;
 				margin-inline: auto;

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -80,8 +80,10 @@ import { BaseLayout } from '~layouts';
 			</p>
 			<p class="u-text-small">
 				💡 Want a reminder of our next application window?
-				<a href="/ics/Q1-2023-Application-Window.ics" download
-					>Download this iCal file!</a
+				<a
+					href="/ics/Q1-2023-Application-Window.ics"
+					download
+					style="color: var(--color-black-light);">Download this iCal file!</a
 				>
 			</p>
 		</div>


### PR DESCRIPTION
## Summary
This PR corrects a few errant link colors, and also sets a yellow background across the whole footer until the split-background feature can be reimplemented.

## Screenshots
iCal link on "Participarte":
<img width="400" alt="CleanShot 2022-12-20 at 14 08 34@2x" src="https://user-images.githubusercontent.com/13525251/208776274-fb0cb9d7-6827-4ae3-b1fd-9552584fcb32.png">

Footer link
<img width="290" alt="CleanShot 2022-12-20 at 14 09 31@2x" src="https://user-images.githubusercontent.com/13525251/208776373-4d899446-cc0e-4699-b22a-8b050988fbea.png">

## Test plan
1. Open [the deploy preview](https://deploy-preview-14--tcl-site-next.netlify.app/participate)
2. Verify that the ical link in the "How to apply" section is visible
3. Scroll down to the footer
4. Verify that the links therein are black
