### PR TITLE
feat: add skip-to-content links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ import { donationOptions } from '~data';
 <footer>
 	<div class="l-center--wide l-grid">
 		<section>
-			<h2 id="support">Support Collab Lab!</h2>
+			<h2 id="support-collab-lab">Support Collab Lab!</h2>
 			<p>
 				The Collab Lab is
 				<strong>volunteer-driven and free for developers.</strong>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -54,6 +54,8 @@ const jsonLDSchema = JSON.stringify(
 		></script>
 	</head>
 	<body>
+		<a href={`#${skipTargetId}`} class="c-skip-link">Skip to content</a>
+		<a href="#support-collab-lab" class="c-skip-link">Skip to footer</a>
 		<Header />
 		<main>
 			<slot />
@@ -318,6 +320,23 @@ const jsonLDSchema = JSON.stringify(
 			.l-switcher > :nth-last-child(n + 5),
 			.l-switcher > :nth-last-child(n + 5) ~ * {
 				flex-basis: 100%;
+			}
+
+			.c-skip-link {
+				appearance: button;
+				background-color: var(--color-pink-mid);
+				border-radius: 4px;
+				color: inherit;
+				min-width: 16ch;
+				padding: 0.5rem 1.6rem;
+				position: absolute;
+				text-align: center;
+				text-decoration: none;
+				transform: translate(-100%, -100%);
+			}
+
+			.c-skip-link:focus-visible {
+				transform: translate(0, 0);
 			}
 
 			.c-donation-button {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,10 +3,11 @@ import { Footer, Header } from '~components';
 
 export interface Props {
 	subtitle?: string;
+	skipTargetId?: string;
 	title: string;
 }
 
-const { title } = Astro.props as Props;
+const { title, skipTargetId } = Astro.props as Props;
 
 const jsonLDSchema = JSON.stringify(
 	{

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -193,6 +193,7 @@ const jsonLDSchema = JSON.stringify(
 				font-family: var(--font-stack);
 				font-weight: 700;
 				line-height: 1.25;
+				text-align: left;
 			}
 
 			h1,

--- a/src/pages/code-of-conduct.astro
+++ b/src/pages/code-of-conduct.astro
@@ -6,7 +6,7 @@ const firstHeadingId = 'code-of-conduct';
 
 <BaseLayout title="Code of Conduct" skipTargetId={firstHeadingId}>
 	<div class="l-center">
-		<h2 id={firstHeadingId}>Code of Conduct</h2>
+		<h1 id={firstHeadingId} class="h2">Code of Conduct</h1>
 		<p>
 			The Collab Lab is dedicated to providing a harassment-free experience for
 			everyone. We do not tolerate harassment of developers in any form.

--- a/src/pages/code-of-conduct.astro
+++ b/src/pages/code-of-conduct.astro
@@ -1,10 +1,12 @@
 ---
 import { BaseLayout } from '~layouts';
+
+const firstHeadingId = 'code-of-conduct';
 ---
 
-<BaseLayout title="Code of Conduct">
+<BaseLayout title="Code of Conduct" skipTargetId={firstHeadingId}>
 	<div class="l-center">
-		<h2>Code of Conduct</h2>
+		<h2 id={firstHeadingId}>Code of Conduct</h2>
 		<p>
 			The Collab Lab is dedicated to providing a harassment-free experience for
 			everyone. We do not tolerate harassment of developers in any form.

--- a/src/pages/developers.astro
+++ b/src/pages/developers.astro
@@ -11,11 +11,13 @@ const mentorsCount = volunteers.filter((volunteer) =>
 // if/when we do more in the future this magic `3` will need to be
 // updated
 const developersCount = (teams.length - 3) * 4;
+
+const firstHeadingId = 'collab-lab-developers';
 ---
 
-<BaseLayout title="Developers">
+<BaseLayout title="Developers" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide">
-		<h2>Collab Lab developers</h2>
+		<h2 id={firstHeadingId}>Collab Lab developers</h2>
 		<!-- <div>
 		<figure>
 			<img src="/img/stats/Women.svg" alt="Women 78%" />

--- a/src/pages/developers.astro
+++ b/src/pages/developers.astro
@@ -17,7 +17,7 @@ const firstHeadingId = 'collab-lab-developers';
 
 <BaseLayout title="Developers" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide">
-		<h2 id={firstHeadingId}>Collab Lab developers</h2>
+		<h1 id={firstHeadingId} class="h2">Collab Lab developers</h1>
 		<!-- <div>
 		<figure>
 			<img src="/img/stats/Women.svg" alt="Women 78%" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,14 @@
 ---
 import { BaseLayout } from '~layouts';
+
+const firstHeadingId = 'gain-practical-experience';
 ---
 
-<BaseLayout title="The Collab Lab">
+<BaseLayout title="The Collab Lab" skipTargetId={firstHeadingId}>
 	<section>
 		<div class="c-jumbo-heading u-border-left pink">
 			<div class="l-center--wide">
-				<h1>
+				<h1 id={firstHeadingId}>
 					Gain <strong>practical experience</strong> by working remotely on<strong
 					>
 						real world projects</strong

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -2,12 +2,14 @@
 import { BaseLayout } from '~layouts';
 ---
 
-<BaseLayout title="Participate">
+<BaseLayout title="Participate" skipTargetId="about-the-collab-lab-program">
 	<section>
 		<div class="l-center--wide">
 			<div class="l-switcher">
 				<div class="o-grid-item">
-					<h2>About The Collab Lab Program</h2>
+					<h2 id="about-the-collab-lab-program">
+						About The Collab Lab Program
+					</h2>
 					<ul>
 						<li>
 							<span class="u-text-bold">Project type:</span> Client-side JavaScript

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -7,9 +7,9 @@ import { BaseLayout } from '~layouts';
 		<div class="l-center--wide">
 			<div class="l-switcher">
 				<div class="o-grid-item">
-					<h2 id="about-the-collab-lab-program">
+					<h1 id="about-the-collab-lab-program" class="h2">
 						About The Collab Lab Program
-					</h2>
+					</h1>
 					<ul>
 						<li>
 							<span class="u-text-bold">Project type:</span> Client-side JavaScript

--- a/src/pages/tech-talks.astro
+++ b/src/pages/tech-talks.astro
@@ -1,11 +1,13 @@
 ---
 import { BaseLayout } from '~layouts';
 import { techTalks } from '~data';
+
+const firstHeadingId = 'tech-talks';
 ---
 
-<BaseLayout title="Tech talks">
+<BaseLayout title="Tech talks" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide">
-		<h2>Tech talks</h2>
+		<h2 id={firstHeadingId}>Tech talks</h2>
 		<div class="l-grid">
 			<p class="c-box pink">
 				Join us for a new Tech Talk on the 2nd Wednesday of every month.

--- a/src/pages/tech-talks.astro
+++ b/src/pages/tech-talks.astro
@@ -7,7 +7,7 @@ const firstHeadingId = 'tech-talks';
 
 <BaseLayout title="Tech talks" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide">
-		<h2 id={firstHeadingId}>Tech talks</h2>
+		<h1 id={firstHeadingId} class="h2">Tech talks</h1>
 		<div class="l-grid">
 			<p class="c-box pink">
 				Join us for a new Tech Talk on the 2nd Wednesday of every month.

--- a/src/pages/volunteer.astro
+++ b/src/pages/volunteer.astro
@@ -2,12 +2,14 @@
 import { Volunteer } from '~components';
 import { volunteers } from '~data';
 import { BaseLayout } from '~layouts';
+
+const firstHeadingId = 'volunteer-at-the-collab-lab';
 ---
 
-<BaseLayout title="Volunteers">
+<BaseLayout title="Volunteers" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide l-switcher">
 		<div class="l-stack">
-			<h2>Volunteer at The Collab Lab!</h2>
+			<h2 id={firstHeadingId}>Volunteer at The Collab Lab!</h2>
 			<p>
 				The Collab Lab is run by an amazing bunch of volunteers that do
 				different things to keep the lights on.

--- a/src/pages/volunteer.astro
+++ b/src/pages/volunteer.astro
@@ -9,7 +9,7 @@ const firstHeadingId = 'volunteer-at-the-collab-lab';
 <BaseLayout title="Volunteers" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide l-switcher">
 		<div class="l-stack">
-			<h2 id={firstHeadingId}>Volunteer at The Collab Lab!</h2>
+			<h1 id={firstHeadingId} class="h2">Volunteer at The Collab Lab!</h1>
 			<p>
 				The Collab Lab is run by an amazing bunch of volunteers that do
 				different things to keep the lights on.


### PR DESCRIPTION
## Summary

Adds two skip-to-content links to every page:
- one linking to the first heading in the `main` region of the page
- one linking to the first heading in the `footer` region of the page

These links are only visible to sighted users if the user presses `Tab` right at the beginning of the page.

<img width="199" alt="CleanShot 2022-12-21 at 12 29 12@2x" src="https://user-images.githubusercontent.com/13525251/208997420-da2690fc-0794-4072-b29a-7177d2de201e.png">
