### PR TITLE
chore: remove unused Hygraph data

### DIFF
--- a/src/data/graphql-data.ts
+++ b/src/data/graphql-data.ts
@@ -3,15 +3,7 @@ import { request } from 'graphql-request';
 import { ComposedQuery } from './graphql-queries';
 import type { ComposedQueryResponse } from './graphql-types';
 
-const monthAndYearFormat = new Intl.DateTimeFormat('en-US', {
-	month: 'long',
-	year: 'numeric',
-});
-const fullDateShortMonthFormat = new Intl.DateTimeFormat('en-US', {
-	month: 'short',
-	day: 'numeric',
-	year: 'numeric',
-});
+import { DateFormatters } from '~utils';
 
 /**
  * Transforms two dates of type 2020-10-10 and 2020-11-11 to
@@ -20,8 +12,8 @@ const fullDateShortMonthFormat = new Intl.DateTimeFormat('en-US', {
  * Used in the Teams section.
  */
 const calculatedDate = ({ startDate, endDate }: Record<string, string>) => {
-	const formattedStartDate = monthAndYearFormat.format(new Date(startDate));
-	const formattedEndDate = monthAndYearFormat.format(new Date(endDate));
+	const formattedStartDate = DateFormatters.monthYear(new Date(startDate));
+	const formattedEndDate = DateFormatters.monthYear(new Date(endDate));
 
 	// if the years are the same, don’t show the year twice
 	// e.g. "October 2020 – November 2020" -> "October – November 2020"
@@ -98,7 +90,7 @@ function getTeams() {
 function getTechTalksData() {
 	return hygraphResponse.techTalks.map((talk) => {
 		const rgx = /(v=([\w-]+))|(be\/([\w-]+))/; // there's probably room for improvement here
-		talk.formattedDate = fullDateShortMonthFormat.format(
+		talk.formattedDate = DateFormatters.fullDateShortMonth(
 			new Date(talk.dateAndTime),
 		);
 		talk.youTubeEmbedUrl = null;

--- a/src/data/graphql-data.ts
+++ b/src/data/graphql-data.ts
@@ -1,7 +1,7 @@
 import { request } from 'graphql-request';
 
 import { ComposedQuery } from './graphql-queries';
-import type { Block, ComposedQueryResponse, Page } from './graphql-types';
+import type { ComposedQueryResponse } from './graphql-types';
 
 const monthAndYearFormat = new Intl.DateTimeFormat('en-US', {
 	month: 'long',
@@ -43,9 +43,6 @@ const hygraphResponse = await request<ComposedQueryResponse>(
 	ComposedQuery,
 );
 
-const getApplicationBlockData = () =>
-	hygraphResponse.applicationBlock.textContent?.html;
-
 const getCollabiesData = () => {
 	const collabies = hygraphResponse.collabies.map((c) => {
 		return {
@@ -83,16 +80,6 @@ const getCollabiesData = () => {
 		mentors,
 		volunteers,
 	};
-};
-
-const getPageDataBySlug = () => {
-	const map: Record<string, Block[]> = {};
-
-	for (const page of hygraphResponse.pages) {
-		map[page.slug] = page.blocks;
-	}
-
-	return map as Record<Page['slug'], Block[]>;
 };
 
 function getTeams() {
@@ -147,9 +134,7 @@ function getTestimonials(): TestimonialFlat[] {
 	});
 }
 
-export const applicationBlock = getApplicationBlockData();
 export const { founders, mentors, volunteers } = getCollabiesData();
-export const pages = getPageDataBySlug();
 export const teams = getTeams();
 export const techTalks = getTechTalksData();
 export const testimonials = getTestimonials();

--- a/src/data/graphql-queries.ts
+++ b/src/data/graphql-queries.ts
@@ -1,15 +1,5 @@
 import { gql } from 'graphql-request';
 
-const ApplicationBlock = gql`
-	fragment ApplicationBlock on Query {
-		applicationBlock: textBlock(where: { id: "ckjwc7a3cak3v0d34n057w44k" }) {
-			textContent {
-				html
-			}
-		}
-	}
-`;
-
 const COLLABIE_DATA_FRAGMENT = gql`
 	fragment collabieData on Collabie {
 		bio {
@@ -46,27 +36,6 @@ const CollabiesAndTeams = gql`
 		}
 	}
 	${COLLABIE_DATA_FRAGMENT}
-`;
-
-const Pages = gql`
-	fragment Pages on Query {
-		pages {
-			slug
-			blocks {
-				__typename
-				... on TextBlock {
-					textContent {
-						html
-					}
-					visible
-				}
-				... on ImageFloatedRight {
-					path
-					caption
-				}
-			}
-		}
-	}
 `;
 
 const TechTalks = gql`
@@ -108,15 +77,11 @@ const Testimonials = gql`
 
 export const ComposedQuery = gql`
 	{
-		...ApplicationBlock
 		...CollabiesAndTeams
-		...Pages
 		...TechTalks
 		...Testimonials
 	}
-	${ApplicationBlock}
 	${CollabiesAndTeams}
-	${Pages}
 	${TechTalks}
 	${Testimonials}
 `;

--- a/src/data/graphql-types.ts
+++ b/src/data/graphql-types.ts
@@ -32,27 +32,6 @@ interface DeveloperTeam {
 	startDate: string;
 }
 
-export interface TextBlock {
-	__typename: 'TextBlock';
-	textContent?: {
-		html: string;
-	};
-	visible: boolean;
-}
-
-export interface ImageFloatedRight {
-	__typename: 'ImageFloatedRight';
-	caption?: string;
-	path: string;
-}
-
-export type Block = TextBlock | ImageFloatedRight;
-
-export interface Page {
-	slug: '/participate/' | '/apply/' | '/mentor/';
-	blocks: Array<Block>;
-}
-
 export interface TechTalk {
 	title: string;
 	presenters: Pick<Collabie, 'fullName'>;
@@ -76,10 +55,8 @@ export interface Testimonial {
 }
 
 export interface ComposedQueryResponse {
-	applicationBlock: TextBlock;
 	collabies: Collabie[];
 	teams: DeveloperTeam[];
-	pages: Page[];
 	techTalks: TechTalk[];
 	testimonials: Testimonial[];
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,10 @@ export const DateFormatters = {
 		month: 'long',
 		timeZone: 'UTC',
 	}).format,
+	monthYear: new Intl.DateTimeFormat('en-US', {
+		month: 'long',
+		year: 'numeric',
+	}).format,
 	fullDateShortMonth: new Intl.DateTimeFormat('en-US', {
 		day: 'numeric',
 		month: 'short',


### PR DESCRIPTION
## Summary

This PR 
- removes code related to the fetching and handling of data we no longer use, and
- moves a date formatter into the `DateFormatters` utility

Note: we don’t use any Testimonials data right now, but we’re still fetching that data because I assume we do want to use it eventually. Happy to remove if this isn’t the case.