### PR TITLE
feat: support cohort region tokens in `ApplicationPrompt`

### DIFF
--- a/src/components/ApplicationPrompt.astro
+++ b/src/components/ApplicationPrompt.astro
@@ -1,9 +1,12 @@
 ---
 import { DateFormatters } from '~utils';
+
+export type CohortRegions = 'North America' | 'Europe/Africa' | 'Latin America';
+
 export interface Props {
 	cohortApplicationWindow: [Date, Date];
 	cohortKickoffDate: Date;
-	cohortRegions: string[];
+	cohortRegions: readonly CohortRegions[];
 }
 
 const {

--- a/src/components/ApplicationPrompt.astro
+++ b/src/components/ApplicationPrompt.astro
@@ -1,13 +1,15 @@
 ---
 import { DateFormatters } from '~utils';
 export interface Props {
-	applicationWindow: [Date, Date];
+	cohortApplicationWindow: [Date, Date];
 	cohortKickoffDate: Date;
+	cohortRegions: string[];
 }
 
 const {
-	applicationWindow: [windowStart, windowEnd],
+	cohortApplicationWindow: [windowStart, windowEnd],
 	cohortKickoffDate,
+	cohortRegions,
 } = Astro.props as Props;
 
 const applicationsOpen = windowStart >= new Date();
@@ -17,11 +19,18 @@ const [formattedWindowStart, formattedWindowEnd] = [
 	DateFormatters.dayMonth(windowStart),
 	DateFormatters.dayMonth(windowEnd),
 ];
+
+const listFormatter = new Intl.ListFormat('en-US', {
+	style: 'long',
+	type: 'conjunction',
+});
+
+const regionList = listFormatter.format(cohortRegions);
 ---
 
 <p class="u-text-large">
 	Our next cohort will kick off on {formattedKickoff}. We will run teams in
-	North America time zones. The application window will be open from {
+	{regionList} time zones. The application window will be open from {
 		formattedWindowStart
 	} to
 	{formattedWindowEnd}. We will notify you of your status the following week.

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,8 @@
 // @ts-expect-error TypeScript doesn't like the .astro file extension
 export { default as ApplicationPrompt } from './ApplicationPrompt.astro';
 // @ts-expect-error TypeScript doesn't like the .astro file extension
+export type { CohortRegions } from './ApplicationPrompt.astro';
+// @ts-expect-error TypeScript doesn't like the .astro file extension
 export { default as GetInTouch } from './GetInTouch.astro';
 // @ts-expect-error TypeScript doesn't like the .astro file extension
 export { default as Footer } from './Footer.astro';

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -1,6 +1,7 @@
 ---
 import { BaseLayout } from '~layouts';
 import { ApplicationPrompt } from '~components';
+import type { CohortRegions } from '~components';
 
 // These date strings must be in UTC time,
 // and must be in the format YYYY-MM-DD
@@ -9,7 +10,8 @@ const cohortApplicationWindow: [Date, Date] = [
 	new Date('2022-12-31 UTC'),
 ];
 const cohortKickoffDate = new Date('2023-01-08 UTC');
-const cohortRegions = ['North America'];
+
+const cohortRegions: CohortRegions[] = ['North America'];
 
 const firstHeadingId = 'about-the-collab-lab-program';
 ---

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -4,11 +4,12 @@ import { ApplicationPrompt } from '~components';
 
 // These date strings must be in UTC time,
 // and must be in the format YYYY-MM-DD
-const applicationWindow: [Date, Date] = [
+const cohortApplicationWindow: [Date, Date] = [
 	new Date('2022-12-24 UTC'),
 	new Date('2022-12-31 UTC'),
 ];
 const cohortKickoffDate = new Date('2023-01-08 UTC');
+const cohortRegions = ['North America'];
 ---
 
 <BaseLayout title="Participate" skipTargetId="about-the-collab-lab-program">
@@ -80,8 +81,9 @@ const cohortKickoffDate = new Date('2023-01-08 UTC');
 		<div class="l-center--wide u-center-text">
 			<h2 id="how-to-apply" class="u-center-text">How to apply</h2>
 			<ApplicationPrompt
-				applicationWindow={applicationWindow}
+				cohortApplicationWindow={cohortApplicationWindow}
 				cohortKickoffDate={cohortKickoffDate}
+				cohortRegions={cohortRegions}
 			/>
 		</div>
 	</section>

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -10,16 +10,16 @@ const cohortApplicationWindow: [Date, Date] = [
 ];
 const cohortKickoffDate = new Date('2023-01-08 UTC');
 const cohortRegions = ['North America'];
+
+const firstHeadingId = 'about-the-collab-lab-program';
 ---
 
-<BaseLayout title="Participate" skipTargetId="about-the-collab-lab-program">
+<BaseLayout title="Participate" skipTargetId={firstHeadingId}>
 	<section>
 		<div class="l-center--wide">
 			<div class="l-switcher">
 				<div class="o-grid-item">
-					<h1 id="about-the-collab-lab-program" class="h2">
-						About The Collab Lab Program
-					</h1>
+					<h1 id={firstHeadingId} class="h2">About The Collab Lab Program</h1>
 					<ul>
 						<li>
 							<span class="u-text-bold">Project type:</span> Client-side JavaScript


### PR DESCRIPTION
## Summary
This PR extends the API of `ApplicationPrompt` so that it expects a `cohortRegions` prop – an array of strings indicating what region(s) we plan to have TCL cohorts.

I also snuck in a fix on the `participate` page, so that properly uses the `firstHeadingId`/`skipTargetId` pattern 🙈 