### PR TITLE
fix: use cleaner logic to determine application openness

### DIFF
--- a/src/components/ApplicationPrompt.astro
+++ b/src/components/ApplicationPrompt.astro
@@ -10,7 +10,7 @@ const {
 	cohortKickoffDate,
 } = Astro.props as Props;
 
-const applicationsOpen = windowStart >= new Date();
+const applicationsOpen = Date.now() > windowStart.getTime();
 
 const formattedKickoff = DateFormatters.fullDateLongMonth(cohortKickoffDate);
 const [formattedWindowStart, formattedWindowEnd] = [
@@ -28,7 +28,7 @@ const [formattedWindowStart, formattedWindowEnd] = [
 </p>
 <>
 	{
-		!applicationsOpen ? (
+		applicationsOpen ? (
 			<p class="u-text-large">
 				<a href="https://airtable.com/shrv9cqaTVHNhCvT1" class="c-button">
 					Apply now!


### PR DESCRIPTION
## Summary
The existing logic works, technically, but it's unintuitive. This implementation is weirder, and more tolerate of time zone differences across build environments (e.g., local machines in PST vs Netlify's servers in UTC)