### PR TITLE
Update participate route on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,8 +68,9 @@ const firstHeadingId = 'gain-practical-experience';
 						their first programming job.
 					</p>
 					<p>
-						You can do it! Head to <a href="/apply">our apply page</a> for the dates
-						of our next cohort!
+						You can do it! Head to <a href="/participate"
+							>our participate page</a
+						> for the dates of our next cohort!
 					</p>
 				</li>
 				<li>


### PR DESCRIPTION
This PR addresses the invalid `/apply` route on the homepage.
The route and text were updated to reflect the `participate` page.

Closes #48 