### PR TITLE
Center collage graphic for overflow on all edges

### DIFF
--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -187,6 +187,7 @@ const firstHeadingId = 'about-the-collab-lab-program';
 			url('/img/participate-developers-collage.webp') type('image/webp'),
 			url('/img/participate-developers-collage.png') type('image/png')
 		);
+		background-position: center;
 		flex-basis: 50%;
 		flex-grow: 0;
 	}


### PR DESCRIPTION
Applied a `background-position: center` to the developer collage so it no longer looked pinned to the top left.

Addresses #19 