### PR TITLE
Add South Asia to the site

### DIFF
--- a/src/components/ApplicationPrompt.astro
+++ b/src/components/ApplicationPrompt.astro
@@ -1,7 +1,7 @@
 ---
 import { DateFormatters } from '~utils';
 
-export type CohortRegions = 'North America' | 'Europe/Africa' | 'Latin America';
+export type CohortRegions = 'North America' | 'Europe/Africa' | 'Latin America' | 'South Asia';
 
 export interface Props {
 	cohortApplicationWindow: [Date, Date];

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -11,7 +11,7 @@ const cohortApplicationWindow: [Date, Date] = [
 ];
 const cohortKickoffDate = new Date('2023-04-02 UTC');
 
-const cohortRegions: CohortRegions[] = ['North America', 'Europe/Africa'];
+const cohortRegions: CohortRegions[] = ['North America', 'Europe/Africa', 'South Asia'];
 
 const firstHeadingId = 'about-the-collab-lab-program';
 ---


### PR DESCRIPTION
- Add `South Asia` as a value to the enum
- Add `South Asia` as a currently active region