### PR TITLE
Add prereqs for CoC and community manager roles

### DIFF
--- a/src/pages/volunteer.astro
+++ b/src/pages/volunteer.astro
@@ -27,7 +27,7 @@ const firstHeadingId = 'volunteer-at-the-collab-lab';
 					code reviews, and presenting learning modules.
 				</p>
 				<p>
-					<b>Commitment</b>: ~5 hours/week for 10 weeks
+					<b>Commitment:</b> ~5 hours/week for 10 weeks
 				</p>
 				<p>
 					Ready to do this? Tell us about you through our <a
@@ -48,7 +48,7 @@ const firstHeadingId = 'volunteer-at-the-collab-lab';
 					interview process.
 				</p>
 				<p>
-					<b>Commitment</b>: ~5 hours per week for 2 weeks
+					<b>Commitment:</b> ~5 hours per week for 2 weeks
 				</p>
 			</details>
 
@@ -71,6 +71,11 @@ const firstHeadingId = 'volunteer-at-the-collab-lab';
 					internal channels poppin’ with fun and helpful events and
 					conversations.
 				</p>
+				<p>
+					<b>Prerequisite:</b> Due to the nature of this role, we require
+					Community Managers to have participated as either a mentor or developer
+					on a project team.
+				</p>
 			</details>
 
 			<details class="roles__details">
@@ -79,8 +84,16 @@ const firstHeadingId = 'volunteer-at-the-collab-lab';
 					At the Collab Lab, we’re dedicated to creating and maintaining an
 					inclusive and psychologically safe space for everyone in our community
 					to learn and grow in. Our Code of Conduct responders are
-					professionally trained and ensure everyone in our community is
-					upholding the commitment to our Code of Conduct.
+					<a
+						href="https://otter.technology/code-of-conduct-training/"
+						>professionally trained</a
+					> and ensure everyone in our community is upholding the commitment to
+					our Code of Conduct.
+				</p>
+				<p>
+					<b>Prerequisite:</b> Due to the nature of this role, we require
+					Code of Conduct Responders to have participated as either a mentor or
+					developer on a project team.
 				</p>
 			</details>
 			<p class="c-callout">


### PR DESCRIPTION
- Add prereqs for CoC and community manager roles
- Moved colons inside the `<b>` tags as god intended
- Linked to our CoC training provider