### PR TITLE
feat: use Hyraph's read-only endpoint to get data

### DIFF
--- a/src/data/graphql-data.ts
+++ b/src/data/graphql-data.ts
@@ -31,7 +31,7 @@ const calculateTeamNumber = (anchor: string) =>
 		: parseInt(anchor.split('-').pop() as string, 10);
 
 const hygraphResponse = await request<ComposedQueryResponse>(
-	'https://api-us-east-1.hygraph.com/v2/ckfwosu634r7l01xpco7z3hvq/master',
+	'https://us-east-1.cdn.hygraph.com/content/ckfwosu634r7l01xpco7z3hvq/master',
 	ComposedQuery,
 );
 


### PR DESCRIPTION
## Summary
Today I learned that Hygraph maintains a handful of different content-management endpoints. Among them are the standard read-and-write endpoint, which we used previously, and the high-performance read-only endpoint, which this PR introduces. 

In addition to allowing faster read operations, this URL has a better caching strategy that only does _partial_ invalidation, so small changes in parts of our content do not result in an expensive re-fetch of all of our data. 

## Resources
- [Hygraph's API reference doc on caching](https://hygraph.com/docs/api-reference/basics/caching) 