### PR TITLE
Add back the "Get Ready" questions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # This file allows us to determine which GitHub users in the TCL community are
-# responsibel for certain parts of the codebase. When someone opens a pull
+# responsible for certain parts of the codebase. When someone opens a pull
 # request that changes a file or directory listed below, GitHub will
 # automatically request a review from the users listed next to it.
 # @see: https://help.github.com/articles/about-codeowners/

--- a/src/pages/developers.astro
+++ b/src/pages/developers.astro
@@ -18,97 +18,97 @@ const firstHeadingId = 'collab-lab-developers';
 <BaseLayout title="Developers" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide">
 		<h1 id={firstHeadingId} class="h2">Collab Lab developers</h1>
-		<!-- <div>
-		<figure>
-			<img src="/img/stats/Women.svg" alt="Women 78%" />
-			<figcaption>
-				<span>78%</span>
-				<span>Women</span>
-			</figcaption>
-		</figure>
-		<figure>
-			<img src="/img/stats/LGBTQ.svg" alt="LGBTQ+ 38%" />
-			<figcaption class="flex-text">
-				<span>38%</span>
-				<span>LGBTQ+</span>
-			</figcaption>
-		</figure>
-		<figure>
-			<img
-				src="/img/stats/IdentifyasDisabled.svg"
-				alt="People with Disabilities 18% "
-			/>
-			<figcaption class="flex-text">
-				<span>18%</span>
-				<span>People with disabilities</span>
-			</figcaption>
-		</figure>
-		<figure>
-			<img
-				src="/img/stats/Advanceddegreeholders.svg"
-				alt="87% Postsecondary degree holders"
-			/>
-			<figcaption class="flex-text">
-				<span>87%</span>
-				<span>Postsecondary degree holders</span>
-			</figcaption>
-		</figure>
-		<figure>
-			<img src="/img/stats/BootcampGrad.svg" alt="75% Bootcamp grads" />
-			<figcaption class="flex-text">
-				<span>75%</span>
-				<span>Bootcamp grads</span>
-			</figcaption>
-		</figure>
-	</div>
+		<div>
+			<figure>
+				<img src="/img/stats/Women.svg" alt="Women 78%" />
+				<figcaption>
+					<span>78%</span>
+					<span>Women</span>
+				</figcaption>
+			</figure>
+			<figure>
+				<img src="/img/stats/LGBTQ.svg" alt="LGBTQ+ 38%" />
+				<figcaption class="flex-text">
+					<span>38%</span>
+					<span>LGBTQ+</span>
+				</figcaption>
+			</figure>
+			<figure>
+				<img
+					src="/img/stats/IdentifyasDisabled.svg"
+					alt="People with Disabilities 18% "
+				/>
+				<figcaption class="flex-text">
+					<span>18%</span>
+					<span>People with disabilities</span>
+				</figcaption>
+			</figure>
+			<figure>
+				<img
+					src="/img/stats/Advanceddegreeholders.svg"
+					alt="87% Postsecondary degree holders"
+				/>
+				<figcaption class="flex-text">
+					<span>87%</span>
+					<span>Postsecondary degree holders</span>
+				</figcaption>
+			</figure>
+			<figure>
+				<img src="/img/stats/BootcampGrad.svg" alt="75% Bootcamp grads" />
+				<figcaption class="flex-text">
+					<span>75%</span>
+					<span>Bootcamp grads</span>
+				</figcaption>
+			</figure>
+		</div>
 
-	<div class="display-stats">
-		<div class="stats-list">
-			<h3>Location</h3>
-			<ul>
-				<li>
-					<span>North America</span>
-					<span class="block block-270px"></span>
-					<span>73%</span>
-				</li>
-				<li>
-					<span>Europe / Africa</span>
-					<span class="block block-65px"></span>
-					<span>17%</span>
-				</li>
-				<li>
-					<span>Latin America</span>
-					<span class="block block-40px"></span>
-					<span>10%</span>
-				</li>
-			</ul>
+		<div class="display-stats">
+			<div class="stats-list">
+				<h3>Location</h3>
+				<ul>
+					<li>
+						<span>North America</span>
+						<span class="block block-270px"></span>
+						<span>73%</span>
+					</li>
+					<li>
+						<span>Europe / Africa</span>
+						<span class="block block-65px"></span>
+						<span>17%</span>
+					</li>
+					<li>
+						<span>Latin America</span>
+						<span class="block block-40px"></span>
+						<span>10%</span>
+					</li>
+				</ul>
+			</div>
+			<div class="stats-list">
+				<h3>Ethnicity</h3>
+				<ul class="ethnicity-list">
+					<li>
+						<span>White</span>
+						<span class="block block-170px"></span>
+						<span>48.9%</span>
+					</li>
+					<li>
+						<span>Black</span>
+						<span class="block block-100px"></span>
+						<span>26.7%</span>
+					</li>
+					<li>
+						<span>Latinx</span>
+						<span class="block block-45px"></span>
+						<span>12.2%</span>
+					</li>
+					<li>
+						<span>Asian</span>
+						<span class="block block-45px"></span>
+						<span>12.2%</span>
+					</li>
+				</ul>
+			</div>
 		</div>
-		<div class="stats-list">
-			<h3>Ethnicity</h3>
-			<ul class="ethnicity-list">
-				<li>
-					<span>White</span>
-					<span class="block block-170px"></span>
-					<span>48.9%</span>
-				</li>
-				<li>
-					<span>Black</span>
-					<span class="block block-100px"></span>
-					<span>26.7%</span>
-				</li>
-				<li>
-					<span>Latinx</span>
-					<span class="block block-45px"></span>
-					<span>12.2%</span>
-				</li>
-				<li>
-					<span>Asian</span>
-					<span class="block block-45px"></span>
-					<span>12.2%</span>
-				</li>
-			</ul>
-		</div>
-	</div> -->
 
 		<p>
 			Nearly all of the developers in The Collab Lab come from

--- a/src/pages/developers.astro
+++ b/src/pages/developers.astro
@@ -18,97 +18,97 @@ const firstHeadingId = 'collab-lab-developers';
 <BaseLayout title="Developers" skipTargetId={firstHeadingId}>
 	<div class="l-center--wide">
 		<h1 id={firstHeadingId} class="h2">Collab Lab developers</h1>
-		<div>
-			<figure>
-				<img src="/img/stats/Women.svg" alt="Women 78%" />
-				<figcaption>
-					<span>78%</span>
-					<span>Women</span>
-				</figcaption>
-			</figure>
-			<figure>
-				<img src="/img/stats/LGBTQ.svg" alt="LGBTQ+ 38%" />
-				<figcaption class="flex-text">
-					<span>38%</span>
-					<span>LGBTQ+</span>
-				</figcaption>
-			</figure>
-			<figure>
-				<img
-					src="/img/stats/IdentifyasDisabled.svg"
-					alt="People with Disabilities 18% "
-				/>
-				<figcaption class="flex-text">
-					<span>18%</span>
-					<span>People with disabilities</span>
-				</figcaption>
-			</figure>
-			<figure>
-				<img
-					src="/img/stats/Advanceddegreeholders.svg"
-					alt="87% Postsecondary degree holders"
-				/>
-				<figcaption class="flex-text">
-					<span>87%</span>
-					<span>Postsecondary degree holders</span>
-				</figcaption>
-			</figure>
-			<figure>
-				<img src="/img/stats/BootcampGrad.svg" alt="75% Bootcamp grads" />
-				<figcaption class="flex-text">
-					<span>75%</span>
-					<span>Bootcamp grads</span>
-				</figcaption>
-			</figure>
-		</div>
+		<!-- <div>
+		<figure>
+			<img src="/img/stats/Women.svg" alt="Women 78%" />
+			<figcaption>
+				<span>78%</span>
+				<span>Women</span>
+			</figcaption>
+		</figure>
+		<figure>
+			<img src="/img/stats/LGBTQ.svg" alt="LGBTQ+ 38%" />
+			<figcaption class="flex-text">
+				<span>38%</span>
+				<span>LGBTQ+</span>
+			</figcaption>
+		</figure>
+		<figure>
+			<img
+				src="/img/stats/IdentifyasDisabled.svg"
+				alt="People with Disabilities 18% "
+			/>
+			<figcaption class="flex-text">
+				<span>18%</span>
+				<span>People with disabilities</span>
+			</figcaption>
+		</figure>
+		<figure>
+			<img
+				src="/img/stats/Advanceddegreeholders.svg"
+				alt="87% Postsecondary degree holders"
+			/>
+			<figcaption class="flex-text">
+				<span>87%</span>
+				<span>Postsecondary degree holders</span>
+			</figcaption>
+		</figure>
+		<figure>
+			<img src="/img/stats/BootcampGrad.svg" alt="75% Bootcamp grads" />
+			<figcaption class="flex-text">
+				<span>75%</span>
+				<span>Bootcamp grads</span>
+			</figcaption>
+		</figure>
+	</div>
 
-		<div class="display-stats">
-			<div class="stats-list">
-				<h3>Location</h3>
-				<ul>
-					<li>
-						<span>North America</span>
-						<span class="block block-270px"></span>
-						<span>73%</span>
-					</li>
-					<li>
-						<span>Europe / Africa</span>
-						<span class="block block-65px"></span>
-						<span>17%</span>
-					</li>
-					<li>
-						<span>Latin America</span>
-						<span class="block block-40px"></span>
-						<span>10%</span>
-					</li>
-				</ul>
-			</div>
-			<div class="stats-list">
-				<h3>Ethnicity</h3>
-				<ul class="ethnicity-list">
-					<li>
-						<span>White</span>
-						<span class="block block-170px"></span>
-						<span>48.9%</span>
-					</li>
-					<li>
-						<span>Black</span>
-						<span class="block block-100px"></span>
-						<span>26.7%</span>
-					</li>
-					<li>
-						<span>Latinx</span>
-						<span class="block block-45px"></span>
-						<span>12.2%</span>
-					</li>
-					<li>
-						<span>Asian</span>
-						<span class="block block-45px"></span>
-						<span>12.2%</span>
-					</li>
-				</ul>
-			</div>
+	<div class="display-stats">
+		<div class="stats-list">
+			<h3>Location</h3>
+			<ul>
+				<li>
+					<span>North America</span>
+					<span class="block block-270px"></span>
+					<span>73%</span>
+				</li>
+				<li>
+					<span>Europe / Africa</span>
+					<span class="block block-65px"></span>
+					<span>17%</span>
+				</li>
+				<li>
+					<span>Latin America</span>
+					<span class="block block-40px"></span>
+					<span>10%</span>
+				</li>
+			</ul>
 		</div>
+		<div class="stats-list">
+			<h3>Ethnicity</h3>
+			<ul class="ethnicity-list">
+				<li>
+					<span>White</span>
+					<span class="block block-170px"></span>
+					<span>48.9%</span>
+				</li>
+				<li>
+					<span>Black</span>
+					<span class="block block-100px"></span>
+					<span>26.7%</span>
+				</li>
+				<li>
+					<span>Latinx</span>
+					<span class="block block-45px"></span>
+					<span>12.2%</span>
+				</li>
+				<li>
+					<span>Asian</span>
+					<span class="block block-45px"></span>
+					<span>12.2%</span>
+				</li>
+			</ul>
+		</div>
+	</div> -->
 
 		<p>
 			Nearly all of the developers in The Collab Lab come from

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -77,6 +77,7 @@ const firstHeadingId = 'about-the-collab-lab-program';
 			</div>
 		</div>
 	</section>
+
 	<section
 		style="background-color: var(--color-blue-mid); color: var(--color-white);"
 	>
@@ -89,6 +90,60 @@ const firstHeadingId = 'about-the-collab-lab-program';
 			/>
 		</div>
 	</section>
+
+	<section>
+		<div class="l-center--wide">
+			<h2 id="get-ready">Get Ready!</h2>
+			<p>Here are the questions we’ll be asking you to answer:</p>
+
+			<ol>
+				<li>
+					<span class="u-text-bold">Name</span>
+				</li>
+				<li>
+					<span class="u-text-bold">Pronouns</span> - Your identity is important
+					to us.
+				</li>
+				<li>
+					<span class="u-text-bold">Region</span> - Depending on mentor availability,
+					we run teams in North America, Latin America, and Europe/Africa.
+				</li>
+				<li>
+					<span class="u-text-bold">Time Zone</span> - Our teams are based in North
+					America, Latin America (in Spanish), and European/African time zones. 🌎🌍
+				</li>
+				<li>
+					<span class="u-text-bold"
+						>Do you agree to abide by The Collab Lab Code of Conduct?</span
+					> - This is non-negotiable. If you want to participate, you must agree
+					to follow the Code of Conduct.
+				</li>
+				<li>
+					<span class="u-text-bold"
+						>Link to a code repository (e.g., GitHub, Gitlab, Bitbucket, etc.)
+						or other example of your work</span
+					> - We use GitHub to host our projects, but mostly this question is about
+					seeing examples of your work so feel free to point us to anything that
+					represents you well. Your best bet is to link directly to a React project.
+					Thanks!
+				</li>
+				<li>
+					<span class="u-text-bold"
+						>What do you hope to learn from participating in The Collab Lab?</span
+					> - We take this question seriously because we want to form teams that
+					are going to support and be open to learning from each other. We are interested
+					in your motivations and aspirations, so help us get to know you!
+				</li>
+				<li>
+					<span class="u-text-bold"
+						>What have you done to learn coding so far?</span
+					> - It’s super helpful for us to understand your coding journey. There
+					is no right or wrong answer to this one!
+				</li>
+			</ol>
+		</div>
+	</section>
+
 	<section class="u-bg-black">
 		<div class="l-center--wide">
 			<div class="l-switcher">

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -201,6 +201,11 @@ const firstHeadingId = 'about-the-collab-lab-program';
 		margin-top: 2.4em;
 	}
 
+	ol {
+		margin-top: 2.4em;
+		padding: 0 2.4em;
+	}
+
 	li + li {
 		margin-top: 1.4em;
 	}


### PR DESCRIPTION
For this PR I:
- created a new section with the "Get Ready" questions, since I didn't want to detract from the info in "How to apply"
- used an ordered list (and styled accordingly) to match the numbered list on the previous website

The design is simple at this point. I'm on the fence as to if an image should be added to match the existing sections due to how much text there is. 

Closes #54 