### PR TITLE
Add design to two of the `role` tags in the Volunteer page 

### DIFF
--- a/src/components/Volunteer.tsx
+++ b/src/components/Volunteer.tsx
@@ -86,10 +86,20 @@ function getBadgeColors(role: CollabieRoles) {
 				backgroundColor: '#0e8a16',
 				color: '#fff',
 			};
+		case 'Career Coach':
+			return {
+				backgroundColor: '#0a6cff',
+				color: '#fff',
+			};
 		case 'Code of Conduct Responder':
 			return {
 				backgroundColor: '#0e8a16',
 				color: '#fff',
+			};
+		case 'Community Manager':
+			return {
+				backgroundColor: '#ff94e8',
+				color: '#000',
 			};
 		case 'Mentor':
 			return {

--- a/src/components/Volunteer.tsx
+++ b/src/components/Volunteer.tsx
@@ -106,6 +106,11 @@ function getBadgeColors(role: CollabieRoles) {
 				backgroundColor: '#fbca04',
 				color: '#000',
 			};
+		case 'Tech Talk Presenter':
+			return {
+				backgroundColor: '#0a6cff',
+				color: '#fff',
+			};
 		case 'Volunteer':
 			return {
 				backgroundColor: '#e34c26',

--- a/src/data/graphql-types.ts
+++ b/src/data/graphql-types.ts
@@ -7,7 +7,8 @@ export type CollabieRoles =
 	| 'Community Manager'
 	| 'Founder'
 	| 'Volunteer'
-	| 'Mentor';
+	| 'Mentor'
+	| 'Tech Talk Presenter';
 
 interface Collabie {
 	bio?: {


### PR DESCRIPTION
Added design to three of the `role` tags in the Volunteer page:  
| Roles             | Foreground Color | Background Color |
|-------------------|------------------|------------------|
| Career Coach      | `#ffffff`           | `#0a6cff`        |
| Community Manager | `#000000`           | `#ff94e8`        |
| Tech Talk Presenter      | `#ffffff`           | `#0a6cff`        |

Addresses #64