### PR TITLE
chore: delete asset path util

### DIFF
--- a/src/components/DeveloperTeam.tsx
+++ b/src/components/DeveloperTeam.tsx
@@ -1,9 +1,5 @@
 import type { DeveloperTeam as DeveloperTeamT } from '~data';
-import {
-	SOCIAL_SITE_NAMES,
-	fixAssetPath,
-	getRandomGenericAvatarPath,
-} from '~utils';
+import { SOCIAL_SITE_NAMES, getRandomGenericAvatarPath } from '~utils';
 
 function renderSocialsList(volunteer: DeveloperTeamT['developers'][number]) {
 	const socialItems = SOCIAL_SITE_NAMES.map((site) => {
@@ -63,10 +59,7 @@ export function DeveloperTeam({ team }: { team: DeveloperTeamT }) {
 							className="team-member-photo"
 							loading="lazy"
 							height="240"
-							src={
-								fixAssetPath(developer.pathToPhoto) ||
-								getRandomGenericAvatarPath()
-							}
+							src={developer.pathToPhoto || getRandomGenericAvatarPath()}
 							width="240"
 						/>
 						<div class="member-caption">

--- a/src/components/VolunteerCard.tsx
+++ b/src/components/VolunteerCard.tsx
@@ -1,9 +1,5 @@
 import type { Collabie, CollabieRoles } from '~data';
-import {
-	SOCIAL_SITE_NAMES,
-	getRandomGenericAvatarPath,
-	fixAssetPath,
-} from '~utils';
+import { SOCIAL_SITE_NAMES, getRandomGenericAvatarPath } from '~utils';
 
 export interface VolunteerProps {
 	hideRoles?: boolean;
@@ -26,7 +22,7 @@ export function VolunteerCard({ hideRoles, volunteer }: VolunteerProps) {
 					className="volunteer__photo"
 					loading="lazy"
 					height="300"
-					src={fixAssetPath(pathToPhoto) || getRandomGenericAvatarPath()}
+					src={pathToPhoto || getRandomGenericAvatarPath()}
 				/>
 				<figcaption className="l-stack" style={{ marginBlock: '1.6em' }}>
 					<span style={{ fontSize: '1.6em', fontWeight: '600' }}>
@@ -85,30 +81,15 @@ function getBadgeColors(role: CollabieRoles) {
 				backgroundColor: '#0e8a16',
 				color: '#fff',
 			};
-		case 'Career Coach':
-			return {
-				backgroundColor: '#0a6cff',
-				color: '#fff',
-			};
 		case 'Code of Conduct Responder':
 			return {
 				backgroundColor: '#0e8a16',
 				color: '#fff',
 			};
-		case 'Community Manager':
-			return {
-				backgroundColor: '#ff94e8',
-				color: '#000',
-			};
 		case 'Mentor':
 			return {
 				backgroundColor: '#fbca04',
 				color: '#000',
-			};
-		case 'Tech Talk Presenter':
-			return {
-				backgroundColor: '#0a6cff',
-				color: '#fff',
 			};
 		case 'Volunteer':
 			return {

--- a/src/components/VolunteerCard.tsx
+++ b/src/components/VolunteerCard.tsx
@@ -1,12 +1,12 @@
 import type { Collabie, CollabieRoles } from '~data';
 import { SOCIAL_SITE_NAMES, getRandomGenericAvatarPath } from '~utils';
 
-export interface VolunteerProps {
+export interface VolunteerCardProps {
 	hideRoles?: boolean;
 	volunteer: Collabie;
 }
 
-export function VolunteerCard({ hideRoles, volunteer }: VolunteerProps) {
+export function VolunteerCard({ hideRoles, volunteer }: VolunteerCardProps) {
 	const { fullName, pathToPhoto, roles } = volunteer;
 	return (
 		<div className="volunteer__grid-item">

--- a/src/components/VolunteerCard.tsx
+++ b/src/components/VolunteerCard.tsx
@@ -81,15 +81,30 @@ function getBadgeColors(role: CollabieRoles) {
 				backgroundColor: '#0e8a16',
 				color: '#fff',
 			};
+		case 'Career Coach':
+			return {
+				backgroundColor: '#0a6cff',
+				color: '#fff',
+			};
 		case 'Code of Conduct Responder':
 			return {
 				backgroundColor: '#0e8a16',
 				color: '#fff',
 			};
+		case 'Community Manager':
+			return {
+				backgroundColor: '#ff94e8',
+				color: '#000',
+			};
 		case 'Mentor':
 			return {
 				backgroundColor: '#fbca04',
 				color: '#000',
+			};
+		case 'Tech Talk Presenter':
+			return {
+				backgroundColor: '#0a6cff',
+				color: '#fff',
 			};
 		case 'Volunteer':
 			return {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,16 +24,6 @@ export const DateFormatters = {
 	}).format,
 };
 
-/**
- * Fix the path to a static asset.
- */
-export function fixAssetPath(path?: string) {
-	// Our CMS expects an /assets/ folder in the path, but
-	// it doesn't exist in this project structure.
-	// TODO: Delete this once the path is fixed in Hygraph.
-	return path?.replace(/^\/assets/, '');
-}
-
 export function getRandomGenericAvatarPath() {
 	const randomIndex = Math.floor(Math.random() * 4);
 


### PR DESCRIPTION
## Summary

I used a little script to update all the Collabie photo paths in our CMS, so that little util function is no longer necessary.

I also snuck in a change to the `VolunteerCardProp` interface's name so it matches the component's name.

## Test plan

Glance over the [volunteer](https://deploy-preview-70--the-collab-lab.netlify.app/volunteer) and [developer](https://deploy-preview-70--the-collab-lab.netlify.app/developers) pages in the deploy preview and double-check that nobody's photo is missing! Note: some people have generic illustrated avatars; this is intentional