### PR TITLE
chore: bundle smaller stylesheets inline

### DIFF
--- a/astro.config.js
+++ b/astro.config.js
@@ -3,6 +3,9 @@ import preact from '@astrojs/preact';
 
 // https://astro.build/config
 export default defineConfig({
+	build: {
+		inlineStylesheets: 'auto',
+	},
 	integrations: [preact()],
 	vite: {
 		server: {


### PR DESCRIPTION
## Summary

We now use a new Astro build option to inline smaller stylesheets for performance. Inline stylesheets cut down on the round-trip cost of a network request. Our largest stylesheet, `globals.css` is still imported using a `link` tag.