### PR TITLE
fix: use correct astro config

### DIFF
--- a/astro.config.js
+++ b/astro.config.js
@@ -7,10 +7,8 @@ export default defineConfig({
 		inlineStylesheets: 'auto',
 	},
 	integrations: [preact()],
-	vite: {
-		server: {
-			open: true,
-		},
+	server: {
+		open: true,
 	},
 	site: 'https://the-collab-lab.codes/',
 });


### PR DESCRIPTION
## Summary
Fixes a developer experience bug in which the dev environment does not automatically open the browser.`server` is now a top-level property, so Astro understands it and opens the browser once the dev server has loaded.