### PR TITLE
update application dates

### DIFF
--- a/public/ics/Feb-2024-Application-Window.ics
+++ b/public/ics/Feb-2024-Application-Window.ics
@@ -25,8 +25,8 @@ END:VTIMEZONE
 BEGIN:VEVENT
 DTSTAMP:20230730T163918Z
 UID:20221226T163918Z-828471998@marudot.com
-DTSTART;VALUE=DATE:20240121
-DTEND;VALUE=DATE:20240128
+DTSTART;VALUE=DATE:20240114
+DTEND;VALUE=DATE:20240121
 SUMMARY:The Collab Lab Applications Open for February 2024
 URL:https://the-collab-lab.codes/participate/
 DESCRIPTION:Applications are now open for the February 2024 Collab Lab cohort. Go to our website to apply!\n\nLas postulaciones están abiertas para nuestro grupo de personas de Febrero 2024. Ve a nuestro sitio web para postularte!

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -6,8 +6,8 @@ import type { CohortRegions } from '~components';
 // These date strings must be in UTC time,
 // and must be in the format YYYY-MM-DD
 const cohortApplicationWindow: [Date, Date] = [
+	new Date('2024-01-14 UTC'),
 	new Date('2024-01-21 UTC'),
-	new Date('2024-01-28 UTC'),
 ];
 const cohortKickoffDate = new Date('2024-02-04 UTC');
 


### PR DESCRIPTION
This PR updates the application window from Jan 14- Jan 21, 2024 to allow for 2 weeks before the cohort kickoff on Feb 4, 2024.
Dates were updated on
- application page
- ical file


closes #77 