### PR TITLE
chore: add dependabot for NPM dependency upgrade management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      assignees:
+        - 'mentalcaries'
+        - 'mxmason'
+      reviewers:
+        - 'mentalcaries'
+        - 'mxmason'


### PR DESCRIPTION
## Summary

Just as it says on the tin: this PR adds [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to this repo. The settings in the new `dependabot.yml` file will cause Dependabot to check for updates once a week. If it finds any updates, it will open a PR for us to incorporate those changes and assign me and @mentalcaries to review and merge it.

If this PR is merged as-is and everything is correct, we should see a Dependabot PR shortly after – I know for a fact that we are slightly out of date.