### PR TITLE
Enable link prefetching

### DIFF
--- a/astro.config.js
+++ b/astro.config.js
@@ -7,6 +7,10 @@ export default defineConfig({
 		inlineStylesheets: 'auto',
 	},
 	integrations: [preact()],
+	prefetch: {
+		defaultStrategy: 'hover',
+		prefetchAll: true,
+	},
 	server: {
 		open: true,
 		port: 3000,


### PR DESCRIPTION
## Summary

Just as it says on the tin! This is a core feature of Astro as of 4.0, and it very slightly decreases the delay required to render a new page upon navigation :)