### PR TITLE
chore: set Dependabot to monthly frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,7 @@ updates:
         - "mentalcaries"
         - "mxmason"
     schedule:
-      interval: "weekly"
-    groups:
-      development-dependencies:
-        dependency-type: "development"
-      production-dependencies:
-        dependency-type: "production"
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Description

This PR does two things to our dependabot config:
1. Removes the dependency groups
2. Sets a monthly update interval, ignoring major package versions

## Rationale
- The site, as a project, is not that risky and doesn't need constant package maintenance. The noise of weekly updates outweighs their value. Reducing the number of groups to one, and limiting updates to only minor versions, will reduce dependabot's noise, while ensuring that dependabot only proposes minimal-risk changes. 
- Major version updates are likely to still be stable, but should probably be managed by a human developer anyway.