### PR TITLE
chore: Update press inquiries contact

### DIFF
--- a/src/components/GetInTouch.astro
+++ b/src/components/GetInTouch.astro
@@ -84,9 +84,9 @@
 				clip-rule="evenodd"></path>
 		</svg>
 		<span>
-			Press inquiries may be directed via email to Andrew at
-			<a href="mailto:andrew@the-collab-lab.codes">
-				andrew@the-collab-lab.codes</a
+			Press inquiries may be directed via email to
+			<a href="mailto:contact@the-collab-lab.codes">
+				contact@the-collab-lab.codes</a
 			>.
 		</span>
 	</li>


### PR DESCRIPTION
Minor update to press inquiries contact in light of Andrew stepping back from TCL:

- Replace `andrew@the-collab-lab.codes` with `contact@the-collab-lab.codes` 
- Remove Andrew's name from press inquiries text