### PR TITLE
Update program duration description

### DIFF
--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -35,8 +35,8 @@ const firstHeadingId = 'about-the-collab-lab-program';
 						</li>
 						<li><span class="u-text-bold">Team size:</span> 4 developers</li>
 						<li>
-							<span class="u-text-bold">Project duration:</span> 40 hours per developer
-							(5 hours/week over 8 weeks)
+							<span class="u-text-bold">Project duration:</span> 60 hours per developer
+							(6 hours/week over 10 weeks)
 						</li>
 					</ul>
 					<p>


### PR DESCRIPTION
This PR updates the program description to now include Career lab: 6 hours per week for 10 weeks, 60 hours total.