### PR TITLE
Add farewell page to website

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1719359061381
+	}
+}

--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -1,9 +1,9 @@
 <div class="l-center banner">
 	<p class="banner__text u-text-large">
-		Notice: The Collab Lab is closing at the end of 2024 -- <a href="/farewell"
-			>more details here</a
-		>. We're excited to announce that we will be running one final cohort. <a
-			href=" /participate">Learn how to apply here!</a
+		<span class="u-text-bold">Notice: </span>The Collab Lab is closing at the
+		end of 2024 -- <a href="/farewell">more details here</a>. We're excited to
+		announce that we will be running one final cohort. <a href=" /participate"
+			>Learn how to apply here!</a
 		>
 	</p>
 </div>

--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -12,7 +12,7 @@
 	.banner {
 		align-self: flex-start;
 		box-sizing: content-box;
-		border: 16px solid var(--color-blue-dark);
+		border: 16px solid var(--color-blue-mid);
 		padding-block: 2rem;
 		padding-inline: 2rem;
 		margin: 3rem auto;

--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -1,5 +1,5 @@
-<div class="l-center banner">
-	<p class="banner__text u-text-large">
+<div class="banner">
+	<p class="u-text-large">
 		<span class="u-text-bold">Notice: </span>The Collab Lab is closing at the
 		end of 2024 -- <a href="/farewell">more details here</a>. We're excited to
 		announce that we will be running one final cohort. <a href=" /participate"
@@ -15,8 +15,8 @@
 		border: 16px solid var(--color-blue-dark);
 		padding-block: 2rem;
 		padding-inline: 2rem;
-		margin-top: 3rem;
+		margin: 3rem auto;
 		background-color: var(--color-yellow-light);
-		max-width: 80vw;
+		max-width: 70vw;
 	}
 </style>

--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -1,0 +1,22 @@
+<div class="l-center banner">
+	<p class="banner__text u-text-large">
+		Notice: The Collab Lab is closing at the end of 2024 -- <a href="/farewell"
+			>more details here</a
+		>. We're excited to announce that we will be running one final cohort. <a
+			href=" /participate">Learn how to apply here!</a
+		>
+	</p>
+</div>
+
+<style>
+	.banner {
+		align-self: flex-start;
+		box-sizing: content-box;
+		border: 16px solid var(--color-blue-dark);
+		padding-block: 2rem;
+		padding-inline: 2rem;
+		margin-top: 3rem;
+		background-color: var(--color-yellow-light);
+		max-width: 80vw;
+	}
+</style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import { Footer, Header } from '~components';
 import '../styles/global.css';
+import Banner from '~components/Banner.astro';
 
 export interface Props {
 	subtitle?: string;
@@ -81,6 +82,7 @@ const jsonLDSchema = JSON.stringify(
 		<a href={`#${skipTargetId}`} class="c-skip-link">Skip to content</a>
 		<a href="#support-collab-lab" class="c-skip-link">Skip to footer</a>
 		<Header />
+		<Banner />
 		<main>
 			<slot />
 		</main>

--- a/src/pages/farewell.astro
+++ b/src/pages/farewell.astro
@@ -1,0 +1,124 @@
+---
+import { BaseLayout } from '~layouts';
+
+const firstHeadingId = 'farewell';
+---
+
+<BaseLayout title="A Memorable Journey's End" skipTargetId={firstHeadingId}>
+	<div class="l-center">
+		<h1 id="{firstHeadingId}" class="h2">A Memorable Journey's End</h1>
+		<p>Dear Collab Lab Community and friends of The Collab Lab,</p>
+		<p>
+			After much thought, we’ve decided to close The Collab Lab at the end of
+			this year. It was an incredibly tough decision, but we believe it’s the
+			right move. Before we wrap up, we have one final cohort ahead of us, and
+			we hope you'll help make it unforgettable! ⭐️
+		</p>
+		<p>
+			Over the years, we've achieved amazing things together.
+			<a href="#developers" style="color: var(--color-blue-mid)"
+				>Hundreds of Collab Lab developers across 25+ countries</a
+			>
+			have found their footing in tech, and many of you have come back to reach a
+			hand back to the next wave of early-career people behind you. Thank you so
+			much for giving back. ❤️
+		</p>
+		<p>
+			So, why are we closing? Running a non-profit solely with volunteers is
+			incredibly challenging. Despite our wonderful community, maintaining
+			sustainability has become tough. We explored many options to keep The
+			Collab Lab going, but they required significant resources and didn’t quite
+			feel right. In consultation with the Board, we’ve decided it was best to
+			close things down cleanly to preserve the legacy we've all built together.
+		</p>
+		<p>
+			Although this decision may come as a shock to many of you who have
+			invested so much into our community, this isn’t goodbye to the spirit of
+			The Collab Lab! We encourage you to take everything you’ve learned and
+			built here and create your own communities, whether local or global. Keep
+			supporting early-career folks and continue the cycle of mentorship and
+			growth.
+		</p>
+
+		<div class="call-to-action-box">
+			<strong>A Call to Action for Employers</strong>
+			<p>
+				To the companies and organizations out there, we have a special message:
+				Please consider hiring early-career engineers. The Collab Lab has been a
+				testament to the incredible potential and talent that these individuals
+				possess.
+			</p>
+			<p>There are myriad benefits to hiring early-career developers:</p>
+			<ul>
+				<li>
+					<strong>Enthusiasm and Motivation:</strong> The enthusiasm they bring to
+					a team is contagious. They can serve as motivation to better document requirements,
+					systems, and processes.
+				</li>
+				<li>
+					<strong>Diversity:</strong> This group tends to include more people from
+					groups underrepresented in tech, making it a great way to increase diversity
+					on your teams.
+				</li>
+			</ul>
+			<p>
+				However, like anything worth doing, you may need to make changes to make
+				the effort successful. Harnessing that enthusiasm takes planning and
+				organization. Increasing the diversity of your team by hiring bootcamp
+				grads only works in the long term if you do the hard work of creating an
+				inclusive, supportive working environment. There are no shortcuts in
+				life or tech, but if you lay the proper groundwork, you’ll set yourself
+				up to help your early-career developers succeed.
+			</p>
+		</div>
+		<p>
+			As we close this chapter, we are excited to announce that we will be
+			running one final cohort. Let's make it our best one yet! This is your
+			chance to be part of something truly special and help us make a lasting
+			impact. We encourage everyone to get involved, share your knowledge, and
+			support our final group of early-career engineers.
+			<strong
+				>If you are an early-career developer,
+				<a href="#participate" style="color: var(--color-blue-mid)"
+					>learn how to apply here</a
+				>! Experienced professionals, your guidance is invaluable and we
+				encourage you to volunteer
+				<a href="#volunteer" style="color: var(--color-blue-mid)">here</a
+				>.</strong
+			>
+		</p>
+		<p>
+			Thank you for being part of this incredible journey with us. We couldn’t
+			have done it without each and every one of you.
+		</p>
+		<p>With all the love, Andrew & Stacie</p>
+	</div>
+</BaseLayout>
+
+<style>
+	* + h2 {
+		margin-bottom: 1em;
+		margin-top: 1em;
+	}
+	p {
+		margin-left: initial;
+		margin-right: initial;
+	}
+	ul {
+		list-style: disc;
+		margin-left: 1.5em;
+	}
+
+	li + li {
+		margin-top: 1em;
+	}
+
+	.call-to-action-box {
+		border: 2px solid #ccc;
+		padding: 1em;
+		margin-top: 1em;
+		margin-bottom: 1em;
+		border-radius: 8px;
+		background-color: #f9f9f9;
+	}
+</style>

--- a/src/pages/farewell.astro
+++ b/src/pages/farewell.astro
@@ -4,19 +4,19 @@ import { BaseLayout } from '~layouts';
 const firstHeadingId = 'farewell';
 ---
 
-<BaseLayout title="A Memorable Journey's End" skipTargetId={firstHeadingId}>
+<BaseLayout title="A Memorable Journey’s End" skipTargetId={firstHeadingId}>
 	<div class="l-center">
-		<h1 id="{firstHeadingId}" class="h2">A Memorable Journey's End</h1>
+		<h1 id="{firstHeadingId}" class="h2">A Memorable Journey’s End</h1>
 		<p>Dear Collab Lab Community and friends of The Collab Lab,</p>
 		<p>
 			After much thought, we’ve decided to close The Collab Lab at the end of
 			this year. It was an incredibly tough decision, but we believe it’s the
 			right move. Before we wrap up, we have one final cohort ahead of us, and
-			we hope you'll help make it unforgettable! ⭐️
+			we hope you’ll help make it unforgettable! ⭐️
 		</p>
 		<p>
-			Over the years, we've achieved amazing things together.
-			<a href="#developers" style="color: var(--color-blue-mid)"
+			Over the years, we’ve achieved amazing things together.
+			<a href="/developers/" style="color: var(--color-blue-mid)"
 				>Hundreds of Collab Lab developers across 25+ countries</a
 			>
 			have found their footing in tech, and many of you have come back to reach a
@@ -29,7 +29,7 @@ const firstHeadingId = 'farewell';
 			sustainability has become tough. We explored many options to keep The
 			Collab Lab going, but they required significant resources and didn’t quite
 			feel right. In consultation with the Board, we’ve decided it was best to
-			close things down cleanly to preserve the legacy we've all built together.
+			close things down cleanly to preserve the legacy we’ve all built together.
 		</p>
 		<p>
 			Although this decision may come as a shock to many of you who have
@@ -73,17 +73,17 @@ const firstHeadingId = 'farewell';
 		</div>
 		<p>
 			As we close this chapter, we are excited to announce that we will be
-			running one final cohort. Let's make it our best one yet! This is your
+			running one final cohort. Let’s make it our best one yet! This is your
 			chance to be part of something truly special and help us make a lasting
 			impact. We encourage everyone to get involved, share your knowledge, and
 			support our final group of early-career engineers.
 			<strong
 				>If you are an early-career developer,
-				<a href="#participate" style="color: var(--color-blue-mid)"
+				<a href="/participate/" style="color: var(--color-blue-mid)"
 					>learn how to apply here</a
 				>! Experienced professionals, your guidance is invaluable and we
 				encourage you to volunteer
-				<a href="#volunteer" style="color: var(--color-blue-mid)">here</a
+				<a href="/volunteer/" style="color: var(--color-blue-mid)">here</a
 				>.</strong
 			>
 		</p>


### PR DESCRIPTION
We need to communicate our farewell messaging on the website so that we can publicly announce the final cohort and closure at the end of the year. 

Feel free to directly contribute to this branch/MR! 🫡 ❤️ 

**Acceptance criteria:** 
- A page is created with a farewell letter that we can link to Linkedin and X posts. 
- A call out exists on the home page that announces the closure, links to the farewell letter, and encourage folks to apply for our next cohort. 