### PR TITLE
Close applications and remove references to future application processes

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1719359061381
+		"lastUpdateCheck": 1722168706441
 	}
 }

--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -2,9 +2,7 @@
 	<p class="u-text-large">
 		<span class="u-text-bold">Notice: </span>The Collab Lab is closing at the
 		end of 2024 — read <a href="/farewell">our farewell anouncement</a> for more
-		info. We&rsquo;re excited to announce that we&rsquo;ll be running one final cohort.
-		Head to <a href="/participate">our &ldquo;participate&rdquo; page</a> to learn
-		more.
+		info.
 	</p>
 </div>
 
@@ -19,6 +17,7 @@
 			line-height: 1.4;
 			margin: 0 auto;
 			max-inline-size: min(95vw, 98rem);
+			text-align: center;
 		}
 	}
 </style>

--- a/src/pages/participate.astro
+++ b/src/pages/participate.astro
@@ -1,17 +1,16 @@
 ---
 import { BaseLayout } from '~layouts';
-import { ApplicationPrompt } from '~components';
-import type { CohortRegions } from '~components';
+// import type { CohortRegions } from '~components';
 
 // These date strings must be in UTC time,
 // and must be in the format YYYY-MM-DD
-const cohortApplicationWindow: [Date, Date] = [
-	new Date('2024-07-21 UTC'),
-	new Date('2024-07-28 UTC'),
-];
-const cohortKickoffDate = new Date('2024-08-11 UTC');
+// const cohortApplicationWindow: [Date, Date] = [
+// 	new Date('2024-07-21 UTC'),
+// 	new Date('2024-07-28 UTC'),
+// ];
+// const cohortKickoffDate = new Date('2024-08-11 UTC');
 
-const cohortRegions: CohortRegions[] = ['North America', 'Europe/Africa'];
+// const cohortRegions: CohortRegions[] = ['North America', 'Europe/Africa'];
 
 const firstHeadingId = 'about-the-collab-lab-program';
 ---
@@ -75,19 +74,6 @@ const firstHeadingId = 'about-the-collab-lab-program';
 					each of the early career engineers who have contributed to The Collab Lab!
 				</p>
 			</div>
-		</div>
-	</section>
-
-	<section
-		style="background-color: var(--color-blue-mid); color: var(--color-white);"
-	>
-		<div class="l-center--wide u-center-text">
-			<h2 id="how-to-apply" class="u-center-text">How to apply</h2>
-			<ApplicationPrompt
-				cohortApplicationWindow={cohortApplicationWindow}
-				cohortKickoffDate={cohortKickoffDate}
-				cohortRegions={cohortRegions}
-			/>
 		</div>
 	</section>
 


### PR DESCRIPTION
As it says above, this closes the currently open applications and removes the "how to apply" section entirely.
Some future discussion will be had about the future of this page